### PR TITLE
Fix typo in OpenAPI docs

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6,7 +6,7 @@ info:
   description: Handles file retrieval for the fcp-fd-file-retriever microservice.
 
 paths: 
-  /object/{id}:
+  /objects/{id}:
     get:
       tags:
         - Object

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-fd-file-retriever",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "File retrieval service for Single Front Door",
   "homepage": "https://github.com/DEFRA/fcp-fd-file-retriever",
   "main": "app/index.js",


### PR DESCRIPTION
Typo was spotted while completing the spike as part of ticket [SFDP-155](https://eaflood.atlassian.net/jira/software/projects/SFDP/boards/1959?selectedIssue=SFDP-155) - this PR is to correct the typo.


[SFDP-155]: https://eaflood.atlassian.net/browse/SFDP-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ